### PR TITLE
dns320l-mcu: Fix compilation with GCC 14

### DIFF
--- a/dns320l-daemon.c
+++ b/dns320l-daemon.c
@@ -26,6 +26,7 @@
 
 */
 
+#include <ctype.h>
 #include <errno.h>
 #include <termios.h>
 #include <unistd.h>
@@ -39,6 +40,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -861,7 +863,7 @@ int main(int argc, char *argv[])
   if (fd < 0)
   {
     syslog(LOG_ERR, "error %d opening %s: %s", errno, stDaemonConfig.portName, strerror (errno));
-    return;
+    return EXIT_FAILURE;
   }
 
   set_interface_attribs (fd, B115200, 0);  // set speed to 115,200 bps, 8n1 (no parity)


### PR DESCRIPTION
This fixes the following compile problem:
```
dns320l-daemon.c: In function 'main':
dns320l-daemon.c:740:18: error: implicit declaration of function 'isprint' [-Wimplicit-function-declaration]
  740 |         else if (isprint (optopt))
      |                  ^~~~~~~
dns320l-daemon.c:50:1: note: include '<ctype.h>' or provide a declaration of 'isprint'
   49 | #include "dns320l-daemon.h"
  +++ |+#include <ctype.h>
   50 |
dns320l-daemon.c:799:5: error: implicit declaration of function 'umask' [-Wimplicit-function-declaration]
  799 |     umask(0);
      |     ^~~~~
dns320l-daemon.c:864:5: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
  864 |     return;
      |     ^~~~~~
dns320l-daemon.c:691:5: note: declared here
  691 | int main(int argc, char *argv[])
      |     ^~~~
```